### PR TITLE
handle non-standard locations of tsh and ~/.tsh

### DIFF
--- a/teleport.el
+++ b/teleport.el
@@ -315,8 +315,9 @@ PREFIX is prepended to the field name."
 
 (defun teleport-mode--filter-by-pattern (column pattern)
   "Add a filter for list of nodes.
-Only nodes with COLUMN matching PATTERN will be shown. The filter
-could be applied to multiple columns. To remove the filter, use `teleport-mode--reset-filter-by-pattern'."
+Only nodes with COLUMN matching PATTERN will be shown.
+The filter could be applied to multiple columns.
+To remove the filter, use \\[teleport-mode--reset-filter-by-pattern]."
   (interactive (list (completing-read "Filter in column: "
                                       (mapcar (lambda (x) (plist-get x :name)) teleport-list-nodes-fields)
                                       #'identity

--- a/teleport.el
+++ b/teleport.el
@@ -79,8 +79,15 @@ Should be unique and not overlap with any existing cmd_labels."
     :group 'teleport
     :type 'string)
 
-(defconst teleport--current-profile-path "~/.tsh/current-profile")
-(defconst teleport--keys-path "~/.tsh/keys/")
+(defcustom teleport-shell-program "tsh"
+  "The name of the Teleport Shell executable."
+  :group 'teleport
+  :type 'string)
+
+(defcustom teleport-shell-config-directory "~/.tsh"
+  "The location of tsh configuration files, usually ~/.tsh."
+  :group 'teleport
+  :type 'string)
 
 (defvar-local teleport-list-nodes--default-directory nil)
 
@@ -228,7 +235,7 @@ Call COMPLETION-NOTIFICATION when a new list is available."
   (teleport--tsh-cmd-async-cached 'teleport--nodes-async-cache
                                   'teleport--nodes-async-process
                                   completion-notification
-                                  "tsh"
+                                  teleport-shell-program
                                   "ls"
                                   "-f"
                                   "json"))
@@ -246,7 +253,7 @@ Call COMPLETION-NOTIFICATION when a new list is available."
   (teleport--tsh-cmd-async-cached 'teleport--logins-async-cache
                                   'teleport--logins-async-process
                                   completion-notification
-                                  "tsh"
+                                  teleport-shell-program
                                   "status"
                                   "-f"
                                   "json"))
@@ -581,8 +588,10 @@ Extract the values of the properties specified in LIST-FORMAT from NODES."
 
 
 (defun teleport--list-clusters ()
-  "Return a list of clusters from ~/.tsh/keys."
-  (directory-files teleport--keys-path nil "^[^.].*"))
+  "Return a list of clusters from ~/.tsh/keys.
+See `teleport-shell-config-directory'."
+  (directory-files (expand-file-name "keys" teleport-shell-config-directory)
+                   nil "^[^.].*"))
 
 
 (defun teleport-switch-to-cluster (cluster)
@@ -592,7 +601,8 @@ And update the list."
                                           (teleport--list-clusters)
                                           #'identity
                                           t)))
-  (write-region cluster nil teleport--current-profile-path)
+  (write-region cluster nil (expand-file-name "current-profile"
+                                              teleport-shell-config-directory))
   (teleport-list-nodes-mode--update-list))
 
 

--- a/teleport.el
+++ b/teleport.el
@@ -80,7 +80,8 @@ Should be unique and not overlap with any existing cmd_labels."
     :type 'string)
 
 (defcustom teleport-shell-program "tsh"
-  "The name of the Teleport Shell executable."
+  "The name of the Teleport Shell executable.
+Set it before calling `teleport-tramp-add-method'."
   :group 'teleport
   :type 'string)
 
@@ -98,10 +99,10 @@ Should be unique and not overlap with any existing cmd_labels."
   (add-to-list
    'tramp-methods
    `(,teleport-tramp-method
-     (tramp-login-program "tsh")
+     (tramp-login-program ,teleport-shell-program)
      (tramp-direct-async t)
      (tramp-login-args (("ssh") ("-l" "%u") ("%h")))
-     (tramp-copy-program "tsh")
+     (tramp-copy-program ,teleport-shell-program)
      (tramp-copy-args (("scp") ("--preserve")))
      (tramp-copy-keep-date t)
      (tramp-remote-shell ,tramp-default-remote-shell)


### PR DESCRIPTION
On windows `~` and `$HOME` may not be the same as `$USERPROFILE` where `.tsh` is located.
The `tsh` executable may be located in `c:/Program Files/Teleport/` and the user may not want to add that single-executable directory to `$PATH`.